### PR TITLE
Blogger: Article Index navigation links

### DIFF
--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -5,3 +5,5 @@
     <li><%= link_to article.title, article_path(article), class: 'article-title', id:"article-#{article.id}" %></li>
   <% end %>
 </ul>
+
+<%= link_to "Create a New Article", new_article_path, class: "new-article" %>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -2,6 +2,6 @@
 
 <ul id="articles">
   <% @articles.each do |article| %>
-    <li><%= article.title %></li>
+    <li><%= link_to article.title, article_path(article), class: 'article-title', id:"article-#{article.id}" %></li>
   <% end %>
 </ul>

--- a/spec/features/user_sees_all_articles_spec.rb
+++ b/spec/features/user_sees_all_articles_spec.rb
@@ -8,8 +8,9 @@ describe "user sees all articles" do
 
       visit "/articles"
 
-      expect(page).to have_content(article_1.title)
-      expect(page).to have_content(article_2.title)
+      expect(page).to have_link(article_1.title)
+      expect(page).to have_link(article_2.title)
+
     end
   end
 end

--- a/spec/features/user_sees_all_articles_spec.rb
+++ b/spec/features/user_sees_all_articles_spec.rb
@@ -10,7 +10,7 @@ describe "user sees all articles" do
 
       expect(page).to have_link(article_1.title)
       expect(page).to have_link(article_2.title)
-
+      expect(page).to have_link("Create a New Article")
     end
   end
 end


### PR DESCRIPTION
Up to this point, I've created an Article Index Page with article titles. In this step, I create navigation links within the index page. First, links for each of the article titles, and then a link to create a new article.
Process:
Create Individual Article Links:
- update assertions in the articles index feature test to include article titles as links (have_link)
- refer to the paths provided by rake routes, and include the path for each link that takes you to that article (article_path(article))
- use a link_to helper in the view to render each article title as a link (link_to)
- add the CSS class (class: 'article-title')
- include a CSS ID attribute with each link (id:"article-#{article.id}")
Create a New Article Link:
- add assertion to the articles index feature test that expects a "Create a New Article" link
- use a link_to helper in the view to display the text "Create a New Article" as a link
- refer to the paths provided by rake routes, and include the path for the link that creates a new article (new_article_path)
- add the CSS class (class: 'new-article')